### PR TITLE
Bugfix 1796

### DIFF
--- a/lambda-example-clean/src/main/java/io/cambium/api/impl/LookupsServiceBean.java
+++ b/lambda-example-clean/src/main/java/io/cambium/api/impl/LookupsServiceBean.java
@@ -16,7 +16,17 @@ import io.cambium.utils.StringUtils;
  * @author Baruch Speiser, Cambium.
  */
 public class LookupsServiceBean implements LookupsService {
-  private static final LookupsRepository repository = ObjectFactory.getLookupsRepository();
+  private final LookupsRepository repository;
+  
+  /** Constructor. */
+  public LookupsServiceBean() {
+    this(ObjectFactory.getLookupsRepository());
+  }
+  
+  /** @param repository */
+  public LookupsServiceBean(LookupsRepository repository) {
+    this.repository = repository;
+  }
 
   /** @see io.cambium.api.LookupsService#lookup(String) */
   public List<LookupData> lookup(String type) {

--- a/lambda-example-clean/src/main/java/io/cambium/persistence/impl/LookupsRepositoryBean.java
+++ b/lambda-example-clean/src/main/java/io/cambium/persistence/impl/LookupsRepositoryBean.java
@@ -3,6 +3,7 @@ package io.cambium.persistence.impl;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -45,7 +46,7 @@ public class LookupsRepositoryBean implements LookupsRepository {
         list.add(lookup);
       }
       return list;
-    } catch(Exception e) {
+    } catch(SQLException e) {
       throw new RuntimeException("Unexpected error", e);
     } finally {
       DatabaseUtils.close(conn, stmt, rs);

--- a/lambda-example-clean/src/test/java/io/cambium/tests/LookupServiceTest.java
+++ b/lambda-example-clean/src/test/java/io/cambium/tests/LookupServiceTest.java
@@ -1,0 +1,50 @@
+package io.cambium.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.cambium.api.impl.LookupsServiceBean;
+import io.cambium.persistence.LookupsRepository;
+import io.cambium.types.models.LookupData;
+
+public class LookupServiceTest {
+
+  @Test
+  public void testService() {
+    LookupsServiceBean service = new LookupsServiceBean(new LookupsRepository() {
+      @Override
+      public List<LookupData> getLookups(String type) {
+        if(!"colors".equals(type)) return Collections.emptyList();
+        return Arrays.asList(
+            new LookupData("colors", "red", "FF0000"),
+            new LookupData("colors", "green", "00FF00"),
+            new LookupData("colors", "blue", "0000FF"));
+      }
+    });
+    
+    assertNotNull(service.lookup(null));
+    assertNotNull(service.lookup(""));
+    assertNotNull(service.lookup("kjghf"));
+    assertEquals(0, service.lookup(null).size());
+    assertEquals(0, service.lookup("").size());
+    assertEquals(0, service.lookup("654").size());
+    List<LookupData> list = service.lookup("colors");
+    assertEquals(3, list.size());
+    try {
+      list.clear();
+      fail("List should be unmodifiable");
+    } catch(UnsupportedOperationException expected) {
+      //ignore
+    }
+    
+    
+  }
+  
+}


### PR DESCRIPTION
Change Lookups service to allow for repository to be injected in the constructor, also fix the exception handling in the repository to only catch SQLExceptions instead of every kind of error.